### PR TITLE
feat: add gofmt & git format hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Check if all go files have been formatted
+unformattedGoFiles=$(gofmt -l .)
+
+if [[ -n "$unformattedGoFiles" ]]; then
+  cat <<\EOF
+Error: There are go files which have not been formatted correctly.
+Run `yarn lint-go` or `gofmt -w .` to fix it.
+EOF
+
+	cat <<EOF
+
+Files which require formatting: $unformattedGoFiles
+EOF
+
+  exit 1
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+init:
+	git config core.hooksPath .githooks

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
         "start": "cd src/app && NODE_ENV=production next start",
         "build-frontend": "cd src/app && next build",
         "build-go": "cd src/go && GOOS=js GOARCH=wasm go build -o ../app/public/main.wasm",
-        "build": "yarn build-go && yarn build-frontend"
+        "build": "yarn build-go && yarn build-frontend",
+        "lint-frontend": "cd src/app && yarn lint",
+        "lint-go": "cd src/go && gofmt -w .",
+        "lint": "yarn lint-frontend && yarn lint-go"
     },
     "dependencies": {}
 }

--- a/src/go/batch/batch.go
+++ b/src/go/batch/batch.go
@@ -5,46 +5,46 @@ import (
 )
 
 type Batcher struct {
-    w Writer
-    size int
-    interval time.Duration
-    lastCommit time.Time
-    batch []interface{}
+	w          Writer
+	size       int
+	interval   time.Duration
+	lastCommit time.Time
+	batch      []interface{}
 }
 
 func NewBatcher(writer Writer, size int, interval time.Duration) *Batcher {
-    return &Batcher{
-        w: writer,
-        size: size,
-        interval: interval,
-        lastCommit: time.Now(),
-    }
+	return &Batcher{
+		w:          writer,
+		size:       size,
+		interval:   interval,
+		lastCommit: time.Now(),
+	}
 }
 
 func (b *Batcher) Write(data interface{}) {
-    b.batch = append(b.batch, data)
+	b.batch = append(b.batch, data)
 
-    if !b.isSizeReached() && !b.isIntervalExpired() {
-        return
-    }
+	if !b.isSizeReached() && !b.isIntervalExpired() {
+		return
+	}
 
-    b.Commit()
+	b.Commit()
 }
 
 func (b *Batcher) isSizeReached() bool {
-    return len(b.batch) >= b.size
+	return len(b.batch) >= b.size
 }
 
 func (b *Batcher) isIntervalExpired() bool {
-    return b.interval != 0 && time.Since(b.lastCommit) < b.interval
+	return b.interval != 0 && time.Since(b.lastCommit) < b.interval
 }
 
 func (b *Batcher) Commit() {
-    if len(b.batch) == 0 {
-        return
-    }
+	if len(b.batch) == 0 {
+		return
+	}
 
-    b.w.Write(b.batch)
-    b.lastCommit = time.Now()
-    b.batch = nil
+	b.w.Write(b.batch)
+	b.lastCommit = time.Now()
+	b.batch = nil
 }

--- a/src/go/batch/writer.go
+++ b/src/go/batch/writer.go
@@ -1,11 +1,11 @@
 package batch
 
 type Writer interface {
-    Write(batch []interface{})
+	Write(batch []interface{})
 }
 
-type WriterFunc func (batch []interface{})
+type WriterFunc func(batch []interface{})
 
 func (w WriterFunc) Write(batch []interface{}) {
-    w(batch)
+	w(batch)
 }

--- a/src/go/bitmask/bitmask.go
+++ b/src/go/bitmask/bitmask.go
@@ -3,19 +3,19 @@ package bitmask
 type Bitmask map[uint64]uint64
 
 func NewBitmask() Bitmask {
-    return Bitmask(make(map[uint64]uint64))
+	return Bitmask(make(map[uint64]uint64))
 }
 
 func (b Bitmask) Set(value int64) {
-    val := uint64(value)
-    index, mask := val / 64, val % 64
+	val := uint64(value)
+	index, mask := val/64, val%64
 
-    b[index] |= (1 << mask)
+	b[index] |= (1 << mask)
 }
 
 func (b Bitmask) Has(value int64) bool {
-    val := uint64(value)
-    index, mask := val / 64, val % 64
+	val := uint64(value)
+	index, mask := val/64, val%64
 
-    return (b[index] & (1 << mask)) != 0
+	return (b[index] & (1 << mask)) != 0
 }

--- a/src/go/dbutil/connect.go
+++ b/src/go/dbutil/connect.go
@@ -2,31 +2,31 @@ package dbutil
 
 import (
 	"context"
-	"log"
 	"github.com/hack-pad/go-indexeddb/idb"
+	"log"
 )
 
 const (
-    DBName = "agloe"
-    DBVersion = 1
-    DBObjectStoreRel = "relations"
-    DBObjectStoreRelIndex = "by_nodeId"
+	DBName                = "agloe"
+	DBVersion             = 1
+	DBObjectStoreRel      = "relations"
+	DBObjectStoreRelIndex = "by_nodeId"
 )
 
 func NewDBConnection() *idb.Database {
-    ctx := context.Background()
-    instance := idb.Global()
-    idbOpenReq, err := instance.Open(ctx, DBName, DBVersion, handleUpgrade)
+	ctx := context.Background()
+	instance := idb.Global()
+	idbOpenReq, err := instance.Open(ctx, DBName, DBVersion, handleUpgrade)
 
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    db, err := idbOpenReq.Await(ctx)
+	db, err := idbOpenReq.Await(ctx)
 
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    return db
+	return db
 }

--- a/src/go/dbutil/upgrade.go
+++ b/src/go/dbutil/upgrade.go
@@ -1,39 +1,38 @@
 package dbutil
 
 import (
+	"github.com/hack-pad/go-indexeddb/idb"
 	"log"
 	"syscall/js"
-	"github.com/hack-pad/go-indexeddb/idb"
 )
 
-func handleUpgrade (db *idb.Database, oldVersion uint, newVersion uint) error {
-    if (oldVersion < 1) {
-        objectStore, err := db.CreateObjectStore(
-            DBObjectStoreRel,
-            idb.ObjectStoreOptions{
-                KeyPath: js.ValueOf("nodeId"),
-                AutoIncrement: false,
-            },
-        )
+func handleUpgrade(db *idb.Database, oldVersion uint, newVersion uint) error {
+	if oldVersion < 1 {
+		objectStore, err := db.CreateObjectStore(
+			DBObjectStoreRel,
+			idb.ObjectStoreOptions{
+				KeyPath:       js.ValueOf("nodeId"),
+				AutoIncrement: false,
+			},
+		)
 
-        if err != nil {
-            log.Fatal(err)
-        }
+		if err != nil {
+			log.Fatal(err)
+		}
 
-        _, err = objectStore.CreateIndex(
-            DBObjectStoreRelIndex,
-            js.ValueOf("nodeId"),
-            idb.IndexOptions{
-                Unique: true,
-                MultiEntry: false,
-            },
-        )
+		_, err = objectStore.CreateIndex(
+			DBObjectStoreRelIndex,
+			js.ValueOf("nodeId"),
+			idb.IndexOptions{
+				Unique:     true,
+				MultiEntry: false,
+			},
+		)
 
-        if err != nil {
-            log.Fatal(err)
-        }
-    }
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 
-    return nil
+	return nil
 }
-

--- a/src/go/entity.go
+++ b/src/go/entity.go
@@ -2,71 +2,71 @@ package main
 
 import (
 	"encoding/json"
-	"syscall/js"
 	"github.com/qedus/osmpbf"
+	"syscall/js"
 )
 
 type Metadata struct {
-    Rank int `json:"rank"`
-    Search string `json:"search"`
+	Rank   int    `json:"rank"`
+	Search string `json:"search"`
 }
 
 type Entity struct {
-    ID int64 `json:"id"`
-    Type string `json:"type"`
-    Name string `json:"name"`
-    Tags map[string]string `json:"tags"`
-    Metadata Metadata `json:"metadata"`
+	ID       int64             `json:"id"`
+	Type     string            `json:"type"`
+	Name     string            `json:"name"`
+	Tags     map[string]string `json:"tags"`
+	Metadata Metadata          `json:"metadata"`
 }
 
 type LatLon struct {
-    Lat float64 `json:"lat"`
-    Lon float64 `json:"lon"`
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
 }
 
 type Node struct {
-    *Entity
-    *LatLon
+	*Entity
+	*LatLon
 }
 
 type Way struct {
-    *Entity
-    Nodes []LatLon `json:"nodes,omitempty"`
+	*Entity
+	Nodes []LatLon `json:"nodes,omitempty"`
 }
 
 func createNode(node *osmpbf.Node, rank int, search string) js.Value {
-    entity := Entity{
-        node.ID,
-        "node",
-        node.Tags["name"],
-        node.Tags,
-        Metadata{rank, search},
-    }
-    latlon := LatLon{node.Lat, node.Lon}
-    marshal := Node{&entity, &latlon}
+	entity := Entity{
+		node.ID,
+		"node",
+		node.Tags["name"],
+		node.Tags,
+		Metadata{rank, search},
+	}
+	latlon := LatLon{node.Lat, node.Lon}
+	marshal := Node{&entity, &latlon}
 
-    json, _ := json.Marshal(marshal)
+	json, _ := json.Marshal(marshal)
 
-    return createJSObject(string(json))
+	return createJSObject(string(json))
 }
 
 func createWay(node *osmpbf.Way, nodes []LatLon, rank int, search string) js.Value {
-    entity := Entity{
-        node.ID,
-        "way",
-        node.Tags["name"],
-        node.Tags,
-        Metadata{rank, search},
-    }
-    way := Way{&entity, nodes}
+	entity := Entity{
+		node.ID,
+		"way",
+		node.Tags["name"],
+		node.Tags,
+		Metadata{rank, search},
+	}
+	way := Way{&entity, nodes}
 
-    json, _ := json.Marshal(way)
+	json, _ := json.Marshal(way)
 
-    return createJSObject(string(json))
+	return createJSObject(string(json))
 }
 
 func createJSObject(entity string) js.Value {
-    JSON := js.Global().Get("JSON")
+	JSON := js.Global().Get("JSON")
 
-    return JSON.Call("parse", entity)
+	return JSON.Call("parse", entity)
 }

--- a/src/go/index.go
+++ b/src/go/index.go
@@ -14,89 +14,89 @@ import (
 )
 
 func index(db *idb.Database) {
-    bitmask := bitmask.NewBitmask()
+	bitmask := bitmask.NewBitmask()
 
-    findWayRelatedNodes(&bitmask)
+	findWayRelatedNodes(&bitmask)
 
-    if (len(bitmask) > 0) {
-        indexNodes(&bitmask, db)
-    }
+	if len(bitmask) > 0 {
+		indexNodes(&bitmask, db)
+	}
 }
 
 /*
  * Finds Nodes on which Way types depend on and adds their IDs to bitmask map
  */
 func findWayRelatedNodes(mask *bitmask.Bitmask) {
-    p = parser.NewParser()
+	p = parser.NewParser()
 
-    p.FetchFile(DEFAULT_FILENAME)
-    p.StartDecoder()
+	p.FetchFile(DEFAULT_FILENAME)
+	p.StartDecoder()
 
-    defer p.Close()
+	defer p.Close()
 
-    for {
-        entity, _, err := p.Parse()
+	for {
+		entity, _, err := p.Parse()
 
-        if err == io.EOF {
-            break
-        } else if err != nil {
-            log.Fatal(err)
-        } else {
-            switch entity := entity.(type) {
-            case *osmpbf.Way:
-                for _, nodeId  := range entity.NodeIDs {
-                    mask.Set(nodeId)
-                }
-            }
-        }
-    }
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatal(err)
+		} else {
+			switch entity := entity.(type) {
+			case *osmpbf.Way:
+				for _, nodeId := range entity.NodeIDs {
+					mask.Set(nodeId)
+				}
+			}
+		}
+	}
 }
 
 /*
  * Adds registered nodes in Bitmask to IndexedDB
  */
 func indexNodes(mask *bitmask.Bitmask, db *idb.Database) {
-    writer := batch.WriterFunc(func (batch []interface{}) {
-        txn, _ := db.Transaction(idb.TransactionReadWrite, dbutil.DBObjectStoreRel)
-        store, _ := txn.ObjectStore(dbutil.DBObjectStoreRel)
+	writer := batch.WriterFunc(func(batch []interface{}) {
+		txn, _ := db.Transaction(idb.TransactionReadWrite, dbutil.DBObjectStoreRel)
+		store, _ := txn.ObjectStore(dbutil.DBObjectStoreRel)
 
-        for _, entry := range batch {
-            store.Add(js.ValueOf(entry))
-        }
+		for _, entry := range batch {
+			store.Add(js.ValueOf(entry))
+		}
 
-        defer txn.Commit()
-    })
-    p := parser.NewParser()
-    b := batch.NewBatcher(writer, 256, 0)
+		defer txn.Commit()
+	})
+	p := parser.NewParser()
+	b := batch.NewBatcher(writer, 256, 0)
 
-    p.FetchFile(DEFAULT_FILENAME)
-    /*
-     * We use osmpbf.Decode instead of agloe.Parse
-     * because agloe.Parse checks if node has name property.
-     */
-    d := p.StartDecoder()
+	p.FetchFile(DEFAULT_FILENAME)
+	/*
+	 * We use osmpbf.Decode instead of agloe.Parse
+	 * because agloe.Parse checks if node has name property.
+	 */
+	d := p.StartDecoder()
 
-    defer p.Close()
-    defer b.Commit()
+	defer p.Close()
+	defer b.Commit()
 
-    for {
-        entity, err := d.Decode()
+	for {
+		entity, err := d.Decode()
 
-        if err == io.EOF {
-            break
-        } else if err != nil {
-            log.Fatal(err)
-        } else {
-            switch entity := entity.(type) {
-            case *osmpbf.Node:
-                if (mask.Has(entity.ID)) {
-                    b.Write(map[string]interface{}{
-                        "nodeId": entity.ID,
-                        "lat": entity.Lat,
-                        "lon": entity.Lon,
-                    })
-                }
-            }
-        }
-    }
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatal(err)
+		} else {
+			switch entity := entity.(type) {
+			case *osmpbf.Node:
+				if mask.Has(entity.ID) {
+					b.Write(map[string]interface{}{
+						"nodeId": entity.ID,
+						"lat":    entity.Lat,
+						"lon":    entity.Lon,
+					})
+				}
+			}
+		}
+	}
 }

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -13,106 +13,106 @@ import (
 )
 
 type Parser struct {
-    decoder *osmpbf.Decoder
-    file io.ReadCloser
-    search string
+	decoder *osmpbf.Decoder
+	file    io.ReadCloser
+	search  string
 }
 
 func NewParser() *Parser {
-    return &Parser{ search: "" }
+	return &Parser{search: ""}
 }
 
 func (p *Parser) GetRank(Tags map[string]string) int {
-    search := p.search
-    name, ok := Tags["name"]
+	search := p.search
+	name, ok := Tags["name"]
 
-    if !ok {
-        return -1;
-    }
+	if !ok {
+		return -1
+	}
 
-    /*
-     * If we get a 1:1 match anywhere in the string then it's automatically 0.
-     */
-    if strings.Contains(strings.ToLower(name), search) {
-        return 0;
-    }
+	/*
+	 * If we get a 1:1 match anywhere in the string then it's automatically 0.
+	 */
+	if strings.Contains(strings.ToLower(name), search) {
+		return 0
+	}
 
-    /*
-     * If all else fails, find Levenshtein distance.
-     */
-    return fuzzy.RankMatchFold(search, name);
+	/*
+	 * If all else fails, find Levenshtein distance.
+	 */
+	return fuzzy.RankMatchFold(search, name)
 }
 
 func (p *Parser) SetSearch(search string) {
-    p.search = search
+	p.search = search
 }
 
 func (p *Parser) Close() {
-    file := p.file
-    file.Close()
+	file := p.file
+	file.Close()
 }
 
 func (p *Parser) FetchFile(filename string) {
-    resp, err := http.Get("/" + filename)
+	resp, err := http.Get("/" + filename)
 
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    file := resp.Body
+	file := resp.Body
 
-    p.file = file
+	p.file = file
 }
 
 func (p *Parser) StartDecoder() *osmpbf.Decoder {
-    if p.file == nil {
-        log.Fatal("No file set")
-    }
+	if p.file == nil {
+		log.Fatal("No file set")
+	}
 
-    decoder := osmpbf.NewDecoder(p.file)
-    decoder.SetBufferSize(osmpbf.MaxBlobSize)
-    err := decoder.Start(runtime.GOMAXPROCS(-1))
+	decoder := osmpbf.NewDecoder(p.file)
+	decoder.SetBufferSize(osmpbf.MaxBlobSize)
+	err := decoder.Start(runtime.GOMAXPROCS(-1))
 
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    p.decoder = decoder
+	p.decoder = decoder
 
-    return decoder
+	return decoder
 }
 
 func (p *Parser) Parse() (interface{}, int, error) {
-    decoder := p.decoder
-    entity, err := decoder.Decode()
+	decoder := p.decoder
+	entity, err := decoder.Decode()
 
-    if err != nil {
-        return nil, -1, err
-    }
+	if err != nil {
+		return nil, -1, err
+	}
 
-    switch entity := entity.(type) {
-        case *osmpbf.Node:
-            rank := p.GetRank(entity.Tags);
+	switch entity := entity.(type) {
+	case *osmpbf.Node:
+		rank := p.GetRank(entity.Tags)
 
-            if (rank > -1) {
-                return entity, rank, nil
-            }
-        case *osmpbf.Way:
-            rank := p.GetRank(entity.Tags);
+		if rank > -1 {
+			return entity, rank, nil
+		}
+	case *osmpbf.Way:
+		rank := p.GetRank(entity.Tags)
 
-            if (rank > -1) {
-                return entity, rank, nil
-            }
-        case *osmpbf.Relation:
-            rank := p.GetRank(entity.Tags);
+		if rank > -1 {
+			return entity, rank, nil
+		}
+	case *osmpbf.Relation:
+		rank := p.GetRank(entity.Tags)
 
-            if (rank > -1) {
-                return entity, rank, nil
-            }
-        default:
-            err := errors.New("unknown type")
-            return nil, -1, err
-    }
+		if rank > -1 {
+			return entity, rank, nil
+		}
+	default:
+		err := errors.New("unknown type")
+		return nil, -1, err
+	}
 
-    return nil, -1, nil
+	return nil, -1, nil
 }


### PR DESCRIPTION
- Add `gofmt -l` pre-commit hook to enforce go formatting.
- Format files using `gofmt`.
- Add `yarn lint-go` & `yarn lint-frontend` commands for ease of use.